### PR TITLE
updating toml and uv lock to incorporate the make sync-time functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ help: ## Display this help.
 	@$(UV) pip install --requirement pyproject.toml
 
 .PHONY: download-libraries
-download-libraries: .venv ## Download the required libraries
+download-libraries: uv .venv ## Download the required libraries
 	@echo "Downloading libraries..."
 	@$(UV) pip install --requirement lib/requirements.txt --target lib --no-deps --upgrade --quiet
 	@rm -rf lib/*.dist-info
@@ -24,6 +24,10 @@ download-libraries: .venv ## Download the required libraries
 pre-commit-install: uv
 	@echo "Installing pre-commit hooks..."
 	@$(UVX) pre-commit install > /dev/null
+
+.PHONY: sync-time
+sync-time: uv ## Syncs th time from your computer to the PROVES Kit board
+	$(UVX) --from git+https://github.com/proveskit/sync-time@1.0.0 sync-time
 
 .PHONY: fmt
 fmt: pre-commit-install ## Lint and format files


### PR DESCRIPTION
## Summary

As sync-time functionality now lives in https://github.com/proveskit/sync-time, it will be installed through the use of uv

## How was this tested
- [ ] Added new unit tests
- [x] Ran code on hardware (screenshots are helpful)

Here is the output of running the `make sync-time` command from the V4 repo.

You will see that the default time on the board is January 1, 2000, but running `make sync-time` updates the time on the board and the correct time is updated

<img width="853" alt="Screenshot 2025-03-28 at 5 36 23 PM" src="https://github.com/user-attachments/assets/fe44322b-f2e5-417c-9579-5eb961964346" />
<img width="1001" alt="Screenshot 2025-03-28 at 5 37 37 PM" src="https://github.com/user-attachments/assets/0467ca49-3948-4019-b864-6b68154059a5" />
<img width="973" alt="Screenshot 2025-03-28 at 5 37 19 PM" src="https://github.com/user-attachments/assets/58ce3773-4c5f-4cbe-a55a-ceb6e56d010e" />
