### PR TITLE
Add hardware version to the general info log at the beginning of main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -46,7 +46,6 @@ logger.info(
     "Booting",
     hardware_version=os.uname().version,
     software_version=__version__,
-    published_date="November 19, 2024",
 )
 
 loiter_time: int = 5

--- a/main.py
+++ b/main.py
@@ -19,6 +19,8 @@ try:
 except ImportError:
     import board
 
+import os
+
 import lib.pysquared.functions as functions
 import lib.pysquared.nvm.register as register
 import lib.pysquared.pysquared as pysquared
@@ -40,7 +42,12 @@ logger: Logger = Logger(
     colorized=False,
 )
 
-logger.info("Booting", software_version=__version__, published_date="November 19, 2024")
+logger.info(
+    "Booting",
+    hardware_version=os.uname().version,
+    software_version=__version__,
+    published_date="November 19, 2024",
+)
 
 loiter_time: int = 5
 


### PR DESCRIPTION
## Summary

I added a hardware_version key and value to the log output early in the program

## How was this tested
- [ ] Added new unit tests
- [x] Ran code on hardware (screenshots are helpful)
<img width="1016" alt="Screenshot 2025-04-01 at 7 51 13 PM" src="https://github.com/user-attachments/assets/51425029-26ce-4989-9859-ddd0f249be20" />

