### PR TITLE
fixed Satellite object construction in REPL

### DIFF
--- a/repl.py
+++ b/repl.py
@@ -12,4 +12,4 @@ logger: Logger = Logger(
 )
 config: Config = Config("config.json")
 logger.info("Initializing a cubesat object as `c` in the REPL...")
-c: Satellite = Satellite(config, logger)
+c: Satellite = Satellite(logger, config)

--- a/repl.py
+++ b/repl.py
@@ -5,7 +5,6 @@ from lib.pysquared.config.config import Config
 from lib.pysquared.logger import Logger
 from lib.pysquared.nvm.counter import Counter
 from lib.pysquared.satellite import Satellite
-from version import __version__
 
 logger: Logger = Logger(
     error_counter=Counter(index=register.ERRORCNT, datastore=microcontroller.nvm),
@@ -13,4 +12,4 @@ logger: Logger = Logger(
 )
 config: Config = Config("config.json")
 logger.info("Initializing a cubesat object as `c` in the REPL...")
-c: Satellite = Satellite(config, logger, __version__)
+c: Satellite = Satellite(config, logger)


### PR DESCRIPTION
## Summary
As the new satellite constructor only takes in config and logger parameters, this was causing an error in the REPL. The error isnt that big of a deal but I think it's affecting the make sync-time command I am trying to fix.

This was the previous error:
<img width="512" alt="Screenshot 2025-04-09 at 5 48 24 PM" src="https://github.com/user-attachments/assets/8b80640e-806e-4271-9a60-a40aa804cd2b" />


I also realized that the logger and config arguments were flipped, so I fixed that
## How was this tested
- [ ] Added new unit tests
- [x] Ran code on hardware (screenshots are helpful)

Below is the REPL now being entered and no errors occurring
<img width="670" alt="Screenshot 2025-04-09 at 5 57 24 PM" src="https://github.com/user-attachments/assets/d0c37030-e798-487e-8167-879e1b7cc553" />


