### PR TITLE
Update repl Functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,11 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 ![CI](https://github.com/proveskit/CircuitPython_RP2040_v4/actions/workflows/ci.yaml/badge.svg)
 
-Software for the v4 PROVES Kit flight control board.
+This is the reference software for the v4x PROVES Kit Flight Controller boards. Clone this repository and use the `make install ...` tooling to get your v4x Flight COntroller Board up and running!
 
 # Development Getting Started
 We welcome contributions, so please feel free to join us. If you have any questions about contributing please open an issue or a discussion.
 
 You can find our Getting Started Guide [here](https://github.com/proveskit/pysquared/blob/main/docs/dev-guide.md).
+
+If you have a mission specific usecase for the CircuitPython Flight Software you can fork this repo and use it as a baseline for developing your own system!

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 ![CI](https://github.com/proveskit/CircuitPython_RP2040_v4/actions/workflows/ci.yaml/badge.svg)
 
-This is the reference software for the v4x PROVES Kit Flight Controller boards. Clone this repository and use the `make install ...` tooling to get your v4x Flight COntroller Board up and running!
+This is the reference software for the v4x PROVES Kit Flight Controller boards. Clone this repository and use the `make install ...` tooling to get your v4x Flight Controller Board up and running!
 
 # Development Getting Started
 We welcome contributions, so please feel free to join us. If you have any questions about contributing please open an issue or a discussion.

--- a/repl.py
+++ b/repl.py
@@ -124,4 +124,4 @@ try:
         pass
 
 except Exception as e:
-    logger.critical("An exception occured within repl.py", e)
+    logger.critical("An exception occurred within repl.py", e)

--- a/repl.py
+++ b/repl.py
@@ -3,8 +3,6 @@ Built for the PySquared FC Board V4x
 Published: May, 2025
 """
 
-import gc
-
 import digitalio
 from busio import SPI
 

--- a/repl.py
+++ b/repl.py
@@ -99,29 +99,5 @@ try:
         cdh,
     )
 
-    def initial_boot():
-        watchdog.pet()
-        f.beacon()
-        watchdog.pet()
-        f.listen()
-        watchdog.pet()
-
-    try:
-        c.boot_count.increment()
-
-        logger.info(
-            "FC Board Stats",
-            bytes_remaining=gc.mem_free(),
-            boot_number=c.boot_count.get(),
-        )
-
-        initial_boot()
-
-    except Exception as e:
-        logger.error("Error in Boot Sequence", e)
-
-    finally:
-        pass
-
 except Exception as e:
     logger.critical("An exception occurred within repl.py", e)

--- a/repl.py
+++ b/repl.py
@@ -4,10 +4,8 @@ Published: May, 2025
 """
 
 import gc
-import time
 
 import digitalio
-import microcontroller
 from busio import SPI
 
 try:
@@ -48,6 +46,7 @@ logger.info(
     software_version=__version__,
 )
 
+try:
     watchdog = Watchdog(logger, board.WDT_WDI)
     watchdog.pet()
 
@@ -123,3 +122,6 @@ logger.info(
 
     finally:
         pass
+
+except Exception as e:
+    logger.critical("An exception occured within repl.py", e)

--- a/repl.py
+++ b/repl.py
@@ -1,13 +1,125 @@
+"""
+Built for the PySquared FC Board V4x
+Published: May, 2025
+"""
+
+import gc
+import time
+
+import digitalio
+import microcontroller
+from busio import SPI
+
+try:
+    from board_definitions import proveskit_rp2040_v4 as board
+except ImportError:
+    import board
+
+import os
+
+import lib.pysquared.functions as functions
 import lib.pysquared.nvm.register as register
+from lib.pysquared.cdh import CommandDataHandler
 from lib.pysquared.config.config import Config
+from lib.pysquared.hardware.busio import _spi_init, initialize_i2c_bus
+from lib.pysquared.hardware.digitalio import initialize_pin
+from lib.pysquared.hardware.imu.manager.lsm6dsox import LSM6DSOXManager
+from lib.pysquared.hardware.magnetometer.manager.lis2mdl import LIS2MDLManager
+from lib.pysquared.hardware.radio.manager.rfm9x import RFM9xManager
 from lib.pysquared.logger import Logger
 from lib.pysquared.nvm.counter import Counter
+from lib.pysquared.nvm.flag import Flag
+from lib.pysquared.rtc.manager.microcontroller import MicrocontrollerManager
 from lib.pysquared.satellite import Satellite
+from lib.pysquared.sleep_helper import SleepHelper
+from lib.pysquared.watchdog import Watchdog
+from version import __version__
+
+rtc = MicrocontrollerManager()
 
 logger: Logger = Logger(
     error_counter=Counter(index=register.ERRORCNT),
     colorized=False,
 )
-config: Config = Config("config.json")
-logger.info("Initializing a cubesat object as `c` in the REPL...")
-c: Satellite = Satellite(logger, config)
+
+logger.info(
+    "Booting",
+    hardware_version=os.uname().version,
+    software_version=__version__,
+)
+
+    watchdog = Watchdog(logger, board.WDT_WDI)
+    watchdog.pet()
+
+    logger.debug("Initializing Config")
+    config: Config = Config("config.json")
+
+    # TODO(nateinaction): fix spi init
+    spi0: SPI = _spi_init(
+        logger,
+        board.SPI0_SCK,
+        board.SPI0_MOSI,
+        board.SPI0_MISO,
+    )
+
+    radio = RFM9xManager(
+        logger,
+        config.radio,
+        Flag(index=register.FLAG, bit_index=7),
+        spi0,
+        initialize_pin(logger, board.SPI0_CS0, digitalio.Direction.OUTPUT, True),
+        initialize_pin(logger, board.RF1_RST, digitalio.Direction.OUTPUT, True),
+    )
+
+    i2c1 = initialize_i2c_bus(
+        logger,
+        board.I2C1_SCL,
+        board.I2C1_SDA,
+        100000,
+    )
+
+    magnetometer = LIS2MDLManager(logger, i2c1)
+
+    imu = LSM6DSOXManager(logger, i2c1, 0x6B)
+
+    c = Satellite(logger, config)
+
+    sleep_helper = SleepHelper(c, logger, watchdog, config)
+
+    cdh = CommandDataHandler(config, logger, radio)
+
+    f = functions.functions(
+        c,
+        logger,
+        config,
+        sleep_helper,
+        radio,
+        magnetometer,
+        imu,
+        watchdog,
+        cdh,
+    )
+
+    def initial_boot():
+        watchdog.pet()
+        f.beacon()
+        watchdog.pet()
+        f.listen()
+        watchdog.pet()
+
+    try:
+        c.boot_count.increment()
+
+        logger.info(
+            "FC Board Stats",
+            bytes_remaining=gc.mem_free(),
+            boot_number=c.boot_count.get(),
+        )
+
+        initial_boot()
+
+    except Exception as e:
+        logger.error("Error in Boot Sequence", e)
+
+    finally:
+        pass


### PR DESCRIPTION
## Summary
This is a pretty straight forward PR. To mirror the way the [v5a repo](https://github.com/proveskit/CircuitPython_RP2350_v5a) is current setup, I propose that we take the entire boot sequence from `main.py` and just copy / paste it into `repl.py`. This is a not a particularly elegant solution to giving functionality to the `REPL`, but it does provide us with a stop gap for allowing people new to the Flight Controller Boards to run some manual tests on hardware to build out some knowledge of how things work!

## How was this tested
- [ ] Added new unit tests
- [ ] Ran code on hardware (screenshots are helpful)
- [ ] Other (Please describe)

I don't have a board at home with me to test this today, but these changes worked when ran in the lab yesterday. I can verify again when I go in tomorrow.