### PR TITLE
Extract the fsk Flag into a use_fsk Object

### DIFF
--- a/main.py
+++ b/main.py
@@ -74,10 +74,12 @@ try:
         board.SPI0_MISO,
     )
 
+    use_fsk = Flag(index=register.FLAG, bit_index=7)
+
     radio = RFM9xManager(
         logger,
         config.radio,
-        Flag(index=register.FLAG, bit_index=7),
+        use_fsk,
         spi0,
         initialize_pin(logger, board.SPI0_CS0, digitalio.Direction.OUTPUT, True),
         initialize_pin(logger, board.RF1_RST, digitalio.Direction.OUTPUT, True),


### PR DESCRIPTION
## Summary
This is a really simple tweak. Currently in the `radio_manager` initialization we are passing an in place creation of a `nvm Flag` object rather than creating the `Flag` object first and then passing it in. 

This PR just extracts that object creation so you can actually call it in the runtime rather than just have it be a static object that cannot be changed. If this conflicts with the new `modify_config` changes that are incoming for the radio feel free to let me know and reject this change!

## How was this tested
- [ ] Added new unit tests
- [ ] Ran code on hardware (screenshots are helpful)
- [ ] Other (Please describe)
