### PR TITLE
Update PySquared to 25w40

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PYSQUARED_VERSION ?= v2.0.0-alpha-25w39
+PYSQUARED_VERSION ?= v2.0.0-alpha-25w40
 PYSQUARED ?= git+https://github.com/proveskit/pysquared@$(PYSQUARED_VERSION)\#subdirectory=circuitpython-workspaces/flight-software
 BOARD_MOUNT_POINT ?= ""
 BOARD_TTY_PORT ?= ""

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-PYSQUARED_VERSION ?= v2.0.0-alpha-25w34
-PYSQUARED ?= git+https://github.com/proveskit/pysquared@$(PYSQUARED_VERSION)
+PYSQUARED_VERSION ?= v2.0.0-alpha-25w39
+PYSQUARED ?= git+https://github.com/proveskit/pysquared@$(PYSQUARED_VERSION)\#subdirectory=circuitpython-workspaces/flight-software
 BOARD_MOUNT_POINT ?= ""
 BOARD_TTY_PORT ?= ""
 VERSION ?= $(shell git tag --points-at HEAD --sort=-creatordate < /dev/null | head -n 1)

--- a/src/flight-software/main.py
+++ b/src/flight-software/main.py
@@ -114,7 +114,8 @@ try:
         packet_manager,
         boot_time,
         imu,
-        magnetometer,
+        # TODO (mikefly123): add back in magnetometer once it is fixed upstream
+        # magnetometer,
         radio,
         error_count,
         boot_count,
@@ -132,7 +133,9 @@ try:
 
         cdh.listen_for_commands(10)
 
-        sleep_helper.safe_sleep(config.sleep_duration)
+        beacon.send()
+
+        cdh.listen_for_commands(config.sleep_duration)
 
     try:
         logger.info("Entering main loop")

--- a/src/flight-software/main.py
+++ b/src/flight-software/main.py
@@ -114,8 +114,7 @@ try:
         packet_manager,
         boot_time,
         imu,
-        # TODO (mikefly123): add back in magnetometer once it is fixed upstream
-        # magnetometer,
+        magnetometer,
         radio,
         error_count,
         boot_count,

--- a/src/flight-software/repl.py
+++ b/src/flight-software/repl.py
@@ -100,8 +100,7 @@ try:
         packet_manager,
         boot_time,
         imu,
-        # TODO (mikefly123): add back in magnetometer once it is fixed upstream
-        # magnetometer,
+        magnetometer,
         radio,
     )
 

--- a/src/flight-software/repl.py
+++ b/src/flight-software/repl.py
@@ -100,7 +100,8 @@ try:
         packet_manager,
         boot_time,
         imu,
-        magnetometer,
+        # TODO (mikefly123): add back in magnetometer once it is fixed upstream
+        # magnetometer,
         radio,
     )
 


### PR DESCRIPTION
## Summary
Bumps the PySquared version and removes the sleep function from the main loop (now that it doesn't actually save any power anymore due to the upstream decision to remove use of the `alarm` module).

This currently also contains the commented out magnetometer in `Beacon`. This is pending behind this bug fix: https://github.com/proveskit/pysquared/issues/310. We can decide to merge as is or wait for that fix to come before merging.

### UPDATE Sept 30
By updating to 25w40 the previously mentioned bug is now fixed! 

## How was this tested
- [ ] Added new unit tests
- [ ] Ran code on hardware (screenshots are helpful)
- [ ] Other (Please describe)
